### PR TITLE
Avoid overwriting SDK or installed libs by zed prebuilt ones

### DIFF
--- a/dev.zed.Zed-Preview.yaml
+++ b/dev.zed.Zed-Preview.yaml
@@ -1,7 +1,7 @@
 # dev.zed.Zed-Preview.yaml
 app-id: dev.zed.Zed-Preview
 runtime: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 command: zed-wrapper
 separate-locales: false
@@ -42,8 +42,8 @@ modules:
       - /share/info
       - /share/man
       - /share/pkgconfig
-      - '*.a'
-      - '*.la'
+      - "*.a"
+      - "*.la"
     config-opts:
       - -Dgtk_doc=false
       - -Dintrospection=false
@@ -108,11 +108,12 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm 755 bin/* --target-directory ${FLATPAK_DEST}/bin
-      - install -Dm 755 lib/* --target-directory ${FLATPAK_DEST}/lib
       - install -Dm 755 libexec/* --target-directory ${FLATPAK_DEST}/libexec
       - install -Dm 644 share/applications/* --target-directory ${FLATPAK_DEST}/share/applications
       - install -Dm 644 ${FLATPAK_ID}.metainfo.xml --target-directory ${FLATPAK_DEST}/share/metainfo
       - install -Dm 644 share/icons/hicolor/512x512/apps/zed.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/zed-preview.png
+      # Only install zed prebuilt libraries that do not already exist in destination
+      - for lib in lib/*; do [ -f "${FLATPAK_DEST}/$lib" ] || install -Dm 755 $lib --target-directory ${FLATPAK_DEST}/lib; done
 
       # Rename instances of `zed` to `${FLATPAK_ID}`
       - rename zed-preview ${FLATPAK_ID} ${FLATPAK_DEST}/share/{applications/*,icons/hicolor/*/apps/*}


### PR DESCRIPTION
zed linux releases come with some prebuilt libs that are also provided by freedesktop Sdk.
The only one not provided by the Sdk is libbsd but it's built and installed by the flatpak as a dependency to netcat

The error comes from libbsd.so.0, a symlink to libbsd.so.0.12.2 being overwritten by zed installation

Checking for lib existence before installing them to avoid overwriting already provided one fixes the problem

See https://github.com/flathub/dev.zed.Zed/pull/240